### PR TITLE
Add ability for custom user-agent parsers to be used and add a custom parser for in-app browsers

### DIFF
--- a/compilers/js.js
+++ b/compilers/js.js
@@ -6,6 +6,9 @@ const path = require("path");
 
 
 // Get document, or throw exception on error
+const customUap = yaml.safeLoad(
+  fs.readFileSync(require.resolve("../regexes.yaml"), "utf8")
+).user_agent_parsers;
 const uap = yaml.safeLoad(
   fs.readFileSync(require.resolve("../uap-core/regexes.yaml"), "utf8")
 ).user_agent_parsers;
@@ -26,7 +29,7 @@ const end = `
   };
 }`;
 let file = "";
-for (const agent of uap) {
+for (const agent of customUap.concat(uap)) {
   const amountOfCapturingGroupsInRegex = (new RegExp(agent.regex + '|')).exec('').length - 1;
   
   let s = "";

--- a/compilers/vcl.js
+++ b/compilers/vcl.js
@@ -30,6 +30,9 @@ function convertToFastlyRegExpCaptureGroups(str) {
     .join(" ");
 }
 
+const customUap = yaml.safeLoad(
+  fs.readFileSync(require.resolve("../regexes.yaml"), "utf8")
+).user_agent_parsers;
 // Get document, or throw exception on error
 const uap = yaml.safeLoad(
   fs.readFileSync(require.resolve("../uap-core/regexes.yaml"), "utf8")
@@ -52,7 +55,7 @@ const end = `
   set req.http.useragent_parser_patch=var.Patch;
 }`;
 let file = "";
-for (const agent of uap) {
+for (const agent of customUap.concat(uap)) {
   const amountOfCapturingGroupsInRegex = (new RegExp(agent.regex + '|')).exec('').length - 1;
   
   let s = "";

--- a/lib/ua_parser.js
+++ b/lib/ua_parser.js
@@ -5,7 +5,12 @@ module.exports = function useragent_parser(ua) {
   let patch;
   let result;
   if (!ua) {
-  } else if (result = /(ESPN)[%20| ]+Radio\/(\d+)\.(\d+)\.(\d+) CFNetwork/.exec(ua)) {
+  } else if (result = /(iPod|iPod touch|iPhone|iPad);.*CPU.*OS[ +](\d+)_(\d+)(?:_(\d+)|).* [A-Za-z]+\/\d+\.\d+\.\d+?/.exec(ua)) {
+		family = "Mobile Safari UI/WKWebView";
+		major = result[2];
+		minor = result[3];
+		patch = result[4];
+	} else if (result = /(ESPN)[%20| ]+Radio\/(\d+)\.(\d+)\.(\d+) CFNetwork/.exec(ua)) {
 		family = result[1];
 		major = result[2];
 		minor = result[3];

--- a/lib/ua_parser.vcl
+++ b/lib/ua_parser.vcl
@@ -8,7 +8,12 @@ sub useragent_parser {
   declare local var.Patch STRING;
   set var.Patch = "";
   if (!req.http.User-Agent) {
-  } else if (req.http.User-Agent ~ {"(ESPN)[%20| ]+Radio/(\d+)\.(\d+)\.(\d+) CFNetwork"}) {
+  } else if (req.http.User-Agent ~ {"(iPod|iPod touch|iPhone|iPad);.*CPU.*OS[ +](\d+)_(\d+)(?:_(\d+)|).* [A-Za-z]+\/\d+\.\d+\.\d+?"}) {
+		set var.Family = "Mobile Safari UI/WKWebView";
+		set var.Major = re.group.2;
+		set var.Minor = re.group.3;
+		set var.Patch = re.group.4;
+	} else if (req.http.User-Agent ~ {"(ESPN)[%20| ]+Radio/(\d+)\.(\d+)\.(\d+) CFNetwork"}) {
 		set var.Family = re.group.1;
 		set var.Major = re.group.2;
 		set var.Minor = re.group.3;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "js-yaml": "^3.13.1",
+    "lodash": "^4.17.11",
     "mocha": "^6.1.4",
     "proclaim": "^3.6.0",
     "yamlparser": "0.0.2"

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1,0 +1,4 @@
+user_agent_parsers:
+  # iOS / OSX Applications
+  - regex: '(iPod|iPod touch|iPhone|iPad);.*CPU.*OS[ +](\d+)_(\d+)(?:_(\d+)|).* [A-Za-z]+\/\d+\.\d+\.\d+?'
+    family_replacement: 'Mobile Safari UI/WKWebView'

--- a/test/user_agent_strings.yaml
+++ b/test/user_agent_strings.yaml
@@ -1,0 +1,194 @@
+# These are user-agent strings which have been overriden by our parser from what the uap-core project expect them to be parsed as
+test_cases:
+
+  - user_agent_string: 'Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '3'
+    minor: '2'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '4'
+    minor: '3'
+    patch: '2'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_0_3 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Coast/3.1.0.79792 Mobile/11B511 Safari/7534.48.3'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '7'
+    minor: '0'
+    patch: '3'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_1 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) OPiOS/8.0.1.80062 Mobile/11D201 Safari/9537.53'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '7'
+    minor: '1'
+    patch: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_6 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Whale/0.9.1.679 Mobile/15D100 Safari/604.5.6'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '11'
+    minor: '2'
+    patch: '6'
+
+  - user_agent_string: 'Mozilla/5.0 (iPad; U; CPU OS 7_0_6 like Mac OS X; de-DE) AppleWebKit/534.35 (KHTML, like Gecko)  Chrome/11.0.696.65 Safari/534.35 Puffin/3.11558IT Mobile'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '7'
+    minor: '0'
+    patch: '6'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 7_0_6 like Mac OS X; de-DE) AppleWebKit/534.35 (KHTML, like Gecko)  Chrome/11.0.696.65 Safari/534.35 Puffin/3.11558IP Mobile'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '7'
+    minor: '0'
+    patch: '6'
+
+  - user_agent_string: 'Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_5 like Mac OS X; en-US) AppleWebKit/534.12 (KHTML, like Gecko) Puffin/1.3.3102MS Mobile Safari/534.12'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '4'
+    minor: '3'
+    patch: '5'
+
+  - user_agent_string: 'Mozilla/5.0 (iPod; U; CPU iPhone OS 5_1_1 like Mac OS X; de-DE) AppleWebKit/534.35 (KHTML, like Gecko)  Chrome/11.0.696.65 Safari/534.35 Puffin/3.9174IP Mobile'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '5'
+    minor: '1'
+    patch: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (iPad; U; CPU iPhone OS 7_0 like Mac OS X; de-DE) WIRED/3.2.3.11.87970'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '7'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '8'
+    minor: '3'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '8'
+    minor: '3'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12D508 [FBAN/GroupsForiOS;FBAV/9.0;FBBV/7752968;FBDV/iPhone7,2;FBMD/iPhone;FBSN/iPhone OS;FBSV/8.2;FBSS/2; FBCR/Telekom.de;FBID/phone;FBLC/de_'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '8'
+    minor: '2'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15G77 [FBAN/FBIOS;FBDV/iPhone10,4;FBMD/iPhone;FBSN/iOS;FBSV/11.4.1;FBSS/2;FBCR/A1;FBID/phone;FBLC/de_DE;FBOP/5;FBRV/122166081]'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '11'
+    minor: '4'
+    patch: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_2_1 like Mac OS X) AppleWebKit/602.4.6 (KHTML, like Gecko) Mobile/14D27 [FBAN/MessengerForiOS;FBAV/124.0.0.50.70;FBBV/63293619;FBDV/iPhone7,1;FBMD/iPhone;FBSN/iOS;FBSV/10.2.1;FBSS/3;FBCR/Viettel;FBID/phone;FBLC/vi_VN;FBOP/5;FBRV/0]'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '10'
+    minor: '2'
+    patch: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15G77 [FBAN/FBIOS;FBAV/194.0.0.38.99;FBBV/127868476;FBDV/iPhone7,2;FBMD/iPhone;FBSN/iOS;FBSV/11.4.1;FBSS/2;FBCR/OrangeBotswana;FBID/phone;FBLC/en_GB;FBOP/5;FBRV/128807018]'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '11'
+    minor: '4'
+    patch: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (iPad; U; CPU OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '4'
+    minor: '3'
+    patch: '2'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Mobile/15A372 Safari Line/7.12.0'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '11'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPad; U; CPU OS 5_1_1 like Mac OS X; en-us) AppleWebKit/534.46.0 (KHTML, like Gecko) Chrome/19.0.1084.60 Mobile/9B206 Safari/7534.48.3'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '5'
+    minor: '1'
+    patch: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_4 like Mac OS X) AppleWebKit/601.1 (KHTML, like Gecko) Outlook-iOS-Android/1.0 Mobile/13G35 Safari/601.1.46")'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '9'
+    minor: '3'
+    patch: '4'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_2_1 like Mac OS X) AppleWebKit/602.4.6 (KHTML, like Gecko) Mobile/14D27 SznProhlizec/4.4i'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '10'
+    minor: '2'
+    patch: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_5 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/11.2.5 Mobile/9B179 Safari/7534.48.3 OktaMobile/5.10.2'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '11'
+    minor: '2'
+    patch: '5'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_5 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D60 Instagram 33.0.0.11.96 (iPhone9,3; iOS 11_2_5; en_AU; en-AU; scale=2.00; gamut=wide; 750x1334)'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '11'
+    minor: '2'
+    patch: '5'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_6 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D100 Flipboard/4.2.2'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '11'
+    minor: '2'
+    patch: '6'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_6 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Snapchat/10.38.0.25 (iPhone8,1; iOS 11.2.6; gzip)'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '11'
+    minor: '2'
+    patch: '6'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0_2 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) GSA/36.0.169645775 Mobile/15A421 Safari/604.1'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '11'
+    minor: '0'
+    patch: '2'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (iPhone; U; fr; CPU iPhone OS 4_2_1 like Mac OS X; fr) AppleWebKit/23.405; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '4'
+    minor: '2'
+    patch: '1'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit/23.411; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '3'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit/23.377; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '3'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.3.24214; iPhone; CPU iPhone OS 4_2_1 like Mac OS X; AppleWebKit/24.783; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '4'
+    minor: '2'
+    patch: '1'
+
+  - user_agent_string: 'Opera/9.80 (J2ME/MIDP; Opera Mini/4.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/23.411; U; en) Presto/2.5.25 Version/10.54'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '3'
+    minor: '2'
+    patch:
+  
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/9.3 Mobile/11A465 Safari/9537.53 VLC for iOS/2.7.2'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '7'
+    minor: '0'
+    patch:

--- a/test/user_agent_strings.yaml
+++ b/test/user_agent_strings.yaml
@@ -1,6 +1,12 @@
 # These are user-agent strings which have been overriden by our parser from what the uap-core project expect them to be parsed as
 test_cases:
 
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_2_1 like Mac OS X) AppleWebKit/602.4.6 (KHTML, like Gecko) Snapchat/10.44.1.1 (iPhone7,2; iOS 10.2.1; gzip)'
+    family: 'Mobile Safari UI/WKWebView'
+    major: '10'
+    minor: '2'
+    patch: '1'
+
   - user_agent_string: 'Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10'
     family: 'Mobile Safari UI/WKWebView'
     major: '3'


### PR DESCRIPTION
Add custom parser for returning all iOS in-app browsers as Mobile Safari